### PR TITLE
fix: use the right url for the page "why pandacss"

### DIFF
--- a/src/content/articles/01-how-does-xxx-compares-to-panda-css.md
+++ b/src/content/articles/01-how-does-xxx-compares-to-panda-css.md
@@ -34,7 +34,7 @@ different ways (`css` / `recipes` / `patterns` / jsx style props, with type-stri
 that to happen. The [ecosystem](https://www.ecopanda.dev/) [is](https://park-ui.com/)
 [growing](https://shadow-panda.dev/), more and more people and companies are using Panda CSS everyday !
 
-A bit more details here: [why Panda CSS](https://panda-css.com/docs/why-panda-css).
+A bit more details here: [why Panda CSS](https://panda-css.com/docs/overview/why-panda).
 
 ## And why NOT Panda CSS?
 


### PR DESCRIPTION
The url you used for more details on "Why PandaCSS" wasn't working (**/overview** missing and **why-panda-css** instead of **why-panda**)